### PR TITLE
Found a bug while using Tandy with postgres.  

### DIFF
--- a/lib/actions/populate.js
+++ b/lib/actions/populate.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Boom = require('boom');
-
+const Ref = require('objection').ref;
 const Actions = require('../actionUtil');
 /**
  * Populate an association
@@ -25,9 +25,9 @@ module.exports = function expand(route, options) {
 
         const Model = actionUtil.modelFromParam(options.model);
         const relation  = options.associationAttr;
-        const Relation = actionUtil.modelFromParam(options.associationAttr);
+        const RelationModel = actionUtil.modelFromParam(options.associationAttr);
 
-        if (!Relation || !Model) {
+        if (!RelationModel || !Model) {
             return Boom.badImplementation('Invalid model or relation');
         }
 
@@ -41,7 +41,7 @@ module.exports = function expand(route, options) {
             .modifyEager(relation, (builder) => {
 
                 builder.skipUndefined()
-                    .where(Relation.tableName + '.' + keys.child.key, '=', keys.child.value)
+                    .where(Ref(RelationModel.tableName + '.' + keys.child.key), '=', keys.child.value)
                     .range(rangeStart, rangeEnd)
                     .limit(limit)
                     .orderByRaw(sort);

--- a/lib/actions/populate.js
+++ b/lib/actions/populate.js
@@ -41,7 +41,7 @@ module.exports = function expand(route, options) {
             .modifyEager(relation, (builder) => {
 
                 builder.skipUndefined()
-                    .where(relation + '.' + keys.child.key, '=', keys.child.value)
+                    .where(Relation.tableName + '.' + keys.child.key, '=', keys.child.value)
                     .range(rangeStart, rangeEnd)
                     .limit(limit)
                     .orderByRaw(sort);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Auto-generated, RESTful, CRUDdy route handlers for Schwifty models in hapi",
   "main": "index.js",
   "scripts": {

--- a/test/models/tokens.js
+++ b/test/models/tokens.js
@@ -8,7 +8,7 @@ module.exports = class tokens extends Model {
 
     static get tableName() {
 
-        return 'tokens';
+        return 'Tokens';
     }
 
     static get joiSchema() {
@@ -29,7 +29,7 @@ module.exports = class tokens extends Model {
                 modelClass: require('./users'),
                 join: {
                     from: 'users.id',
-                    to: 'tokens.user'
+                    to: 'Tokens.user'
                 }
             }
         };

--- a/test/models/users.js
+++ b/test/models/users.js
@@ -30,7 +30,7 @@ module.exports = class Users extends Model {
                 modelClass: require('./tokens'),
                 join: {
                     from: 'users.id',
-                    to: 'tokens.user'
+                    to: 'Tokens.user'
                 }
             }
         };

--- a/test/seeds/test_seed.js
+++ b/test/seeds/test_seed.js
@@ -10,9 +10,9 @@ exports.seed = function (knex, Promise) {
             knex('users').insert({ id: 2, email: 'c@d.e', firstName: 'c', lastName: 'd' }),
             knex('users').insert({ id: 3, email: 'a@d.e', firstName: 'a', lastName: 'd' }),
             knex('users').insert({ id: 4, email: 'd@d.e', firstName: 'd', lastName: 'd' }),
-            knex('tokens').insert({ id: 99, temp: 'text', user: 1 }),
-            knex('tokens').insert({ id: 98, temp: 'test', user: 1 }),
-            knex('tokens').insert({ id: 97, temp: 'noUser', user: null })
+            knex('Tokens').insert({ id: 99, temp: 'text', user: 1 }),
+            knex('Tokens').insert({ id: 98, temp: 'test', user: 1 }),
+            knex('Tokens').insert({ id: 97, temp: 'noUser', user: null })
         ]);
     });
 };


### PR DESCRIPTION
SQLite isn't case sensitive, so in most cases 'token' === 'Token' but that's not the case for all engines.  This fix ensures that relation population will work correctly in case-sensitive environments